### PR TITLE
Chillinmcill patch 1

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1,3 +1,5 @@
+#ifndef FUNCTIONS_H
+#define FUNCTIONS_H
 
 
 unsigned long long __ull_rshift(unsigned long long a0, unsigned long long a1);
@@ -9,3 +11,5 @@ long long __ll_div(long long a0, long long a1);
 unsigned long long __ll_mul(unsigned long long a0, unsigned long long a1);
 void __ull_divremi(unsigned long long *div, unsigned long long *rem, unsigned long long a2, unsigned short a3);
 long long __ll_mod(long long a0, long long a1);
+
+#endif

--- a/include/functions.us.h
+++ b/include/functions.us.h
@@ -177,6 +177,13 @@ void func_802CB360_6DCA10(void);
 
 s32  func_802F8160_709810(s32, s32, s32, s32, s32, s32, s32, s32, f32);
 
+// overlay2_6AB090.c
+void func_802999E0_6AB090(DisplayList *arg0);
+void func_8029A32C_6AB9DC(s32 arg0);
+u16  func_8029A52C_6ABBDC(u8 arg0);
+u16  func_8029A568_6ABC18(s16 arg0);
+void func_8029A5B4_6ABC64(Gfx **arg0, u8 r, u8 g, u8 b);
+
 // overlay2_739290.c
 void func_8032AA94_73C144(void);
 struct025* func_803284C4_739B74(void);

--- a/include/structs.h
+++ b/include/structs.h
@@ -4,7 +4,10 @@
 typedef struct struct035 struct035;
 
 typedef struct {
-    u8  pad0[0xC4];
+    u8  pad0[0xC];
+    s16 unkC;
+    s16 unkE;
+    u8  pad10[0xB4];
     u16 unkC4;
     u16 unkC6;
     u8  unkC8[0x6];
@@ -12,6 +15,8 @@ typedef struct {
     u8  unkD0[0xA];
     u16 unkDA;
     u16 unkDC; // initialised?
+    u8  padDE[0x2];
+    f32 unkE0;
 } struct000;
 
 typedef struct {
@@ -493,5 +498,10 @@ typedef struct {
 typedef struct {
     struct035* unk0;
 } struct037;
+
+typedef struct {
+    s16 unk0;
+    u8  pad2[0xab6];
+} struct038; // size 0xAB8
 
 #endif

--- a/include/variables.us.h
+++ b/include/variables.us.h
@@ -33,6 +33,10 @@ extern s32  D_80000400;
 
 extern s32  D_80025C00;
 
+// 0x800Bxxxx
+
+extern struct038 D_800BB210[];
+
 // 0x8010xxxx
 
 extern s32  D_80100000;
@@ -425,6 +429,7 @@ extern s16  D_803F2D70; // biome (0 Europe, 1 Ice, 2 Desert, 3 Jungle)
 extern s64  D_803C0644;
 extern s64  D_803C064C;
 extern s32  D_803C0654;
+extern u16 *D_803C0658;
 extern Animal *D_803D5530;
 extern s32  D_803D5534; // this is gCurrentAnimalIndex!
 extern s16  gCurrentAnimalIndex; // current animal (id within level)

--- a/src.us/overlay2_6AB090.c
+++ b/src.us/overlay2_6AB090.c
@@ -1,0 +1,61 @@
+#include <ultra64.h>
+
+#include "common.h"
+
+
+void func_802999E0_6AB090(DisplayList *arg0) {
+    guPerspective(&arg0->unk37410, &D_803C0658, D_803F2D50.unkE0, 1.0f, D_803F2D50.unkC, D_803F2D50.unkE, 1.0f);
+    guRotateRPY(&arg0->unk37450, 0.5f, 0.5f, 0.5f);
+    guRotateRPY(&arg0->unk374D0, 1.0f, 1.0f, 1.0f);
+    func_8033F380_750A30();
+}
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_80299AA8_6AB158.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_80299B68_6AB218.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_80299E84_6AB534.s")
+
+void func_8029A32C_6AB9DC(s32 arg0) {
+}
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_8029A334_6AB9E4.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_8029A3B0_6ABA60.s")
+
+u16 func_8029A52C_6ABBDC(u8 arg0) {
+    struct038 *s;
+    u16 tmp = arg0 & 0x3F;
+
+    s = &D_800BB210[tmp];
+    tmp = s->unk0;
+    return tmp;
+}
+
+u16 func_8029A568_6ABC18(s16 arg0) {
+    s16 temp_v0;
+    u16 temp_v1;
+    u16 temp_v2;
+    u16 temp_v3;
+    u16 res;
+
+    temp_v0 = arg0;
+    temp_v1 =  ((temp_v0 & 0x3E) >> 2) & 0x3E;
+    temp_v2 = (((temp_v0 & 0x7C0) >> 7) << 5) & 0x7C0;
+    temp_v3 = (((temp_v0 & 0xF800) >> 12) << 10) & 0xF800;
+
+    res = temp_v1 | temp_v2 | temp_v3;
+    return res;
+}
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_8029A5B4_6ABC64.s")
+// void func_8029A5B4_6ABC64(Gfx **arg0, u8 r, u8 g, u8 b) {
+//     gSPFogPosition((*arg0)++, 1033, 992); // not quite right
+//     gDPSetFogColor((*arg0)++, r, g, b, 0x00);
+// }
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_8029A624_6ABCD4.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_8029A720_6ABDD0.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_6AB090/func_8029ABCC_6AC27C.s")

--- a/sssv.us.yaml
+++ b/sssv.us.yaml
@@ -581,7 +581,7 @@ segments:
     subsections:
     - [0x6A6500, c]
     - [0x6A7A80, asm]
-    - [0x6AB090, asm]
+    - [0x6AB090, c]
     - [0x6AC360, asm]
     - [0x6ACF20, asm]
     - [0x6B5380, asm]


### PR DESCRIPTION
decomped func_8029A32C_6AB9DC and func_8029A52C_6ABBDC in overlay2_6AB090. Also updated the yaml for 0x6AB090 from asm to c, and added variable D_800BB210[] to variables.us.h to support func_8029A52C_6ABBDC.