### PR TITLE
overlay2_73EA30 partial decomp

### DIFF
--- a/include/functions.us.h
+++ b/include/functions.us.h
@@ -298,6 +298,13 @@ s16  func_803051F0_7168A0(s16 arg0, s16 arg1);
 
 void func_803223F4_733AA4(s32);
 
+// overlay2_716530
+s32  func_80304E80_716530(struct039 *arg0);
+void func_80304EC4_716574(struct039 *arg0, struct039 *arg1);
+void func_80304F70_716620(struct039 *arg0, struct039 *arg1, struct039 *arg2);
+s16  func_80305194_716844(s16 arg0, s16 arg1);
+s16  func_803051F0_7168A0(s16 arg0, s16 arg1);
+
 // overlay2_739290.c
 void func_8032AA94_73C144(void);
 struct025* func_803284C4_739B74(void);
@@ -314,6 +321,14 @@ void func_8032C2D0_73D980(s16 arg0, s16 arg1, f32 arg2);
 void func_8032C360_73DA10(s16 arg0, s16 arg1, s16 arg2, s16 arg3, s16 arg4, s16 arg5, f32 arg6);
 void func_8032C508_73DBB8(s16 arg0, s16 arg1, s16 arg2, f32 arg3);
 void func_8032CD20_73E3D0(s32 arg0, s16 arg1, s16 arg2, s16 arg3, f32 arg4);
+
+// overlay2_73EA30
+void func_8032D380_73EA30(Vertex *x, Vertex *y, Vertex *res);
+void func_8032D3B4_73EA64(Vertex *x, Vertex *y, Vertex *res);
+void func_8032D3E8_73EA98(Vertex *x, f32 c, Vertex *res);
+void func_8032D414_73EAC4(Vertex *x, f32 c, Vertex *res);
+f32  func_8032D504_73EBB4(Vertex *x, Vertex *y);
+void func_8032D534_73EBE4(Vertex *x, Vertex *y, Vertex *res);
 
 void func_80304170_715820(void);
 void func_80304194_715844(void);

--- a/include/structs.h
+++ b/include/structs.h
@@ -1022,4 +1022,10 @@ typedef struct {
     s8 unk2[0x30];
 } struct059;
 
+typedef struct {
+    /* 0x00 */ f32 x;
+    /* 0x04 */ f32 y;
+    /* 0x08 */ f32 z;
+} Vertex;
+
 #endif

--- a/src.us/overlay2_73EA30.c
+++ b/src.us/overlay2_73EA30.c
@@ -1,0 +1,55 @@
+#include <ultra64.h>
+#include "common.h"
+
+
+void func_8032D380_73EA30(Vertex *x, Vertex *y, Vertex *res) {
+//vector addition
+    res->x = x->x + y->x;
+    res->y = x->y + y->y;
+    res->z = x->z + y->z;
+}
+
+void func_8032D3B4_73EA64(Vertex *x, Vertex *y, Vertex *res) {
+//vector subtraction
+    res->x = x->x - y->x;
+    res->y = x->y - y->y;
+    res->z = x->z - y->z;
+}
+
+void func_8032D3E8_73EA98(Vertex *x, f32 c, Vertex *res) {
+//multiply vector by a constant
+    res->x = x->x * c;
+    res->y = x->y * c;
+    res->z = x->z * c;
+}
+
+void func_8032D414_73EAC4(Vertex *x, f32 c, Vertex *res) {
+//divide vector by a constant
+    res->x = x->x / c;
+    res->y = x->y / c;
+    res->z = x->z / c;
+}
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_73EA30/func_8032D440_73EAF0.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_73EA30/func_8032D494_73EB44.s")
+
+f32 func_8032D504_73EBB4(Vertex *x, Vertex *y) {
+//dot product
+    f32 x0x1, y0y1, z0z1;
+
+    x0x1 = x->x * y->x;
+    y0y1 = x->y * y->y;
+    z0z1 = x->z * y->z;
+
+    return x0x1 + y0y1 + z0z1;
+}
+
+void func_8032D534_73EBE4(Vertex *x, Vertex *y, Vertex *res) {
+//cross product
+    res->x = x->y * y->z - x->z * y->y;
+    res->y = x->z * y->x - x->x * y->z;
+    res->z = x->x * y->y - x->y * y->x;
+}
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlay2_73EA30/func_8032D5A4_73EC54.s")

--- a/sssv.us.yaml
+++ b/sssv.us.yaml
@@ -627,7 +627,7 @@ segments:
     - [0x732A60, asm]
     - [0x734D30, asm]
     - [0x739290, c] # cheats?
-    - [0x73EA30, asm]
+    - [0x73EA30, c]
     - [0x73ED30, asm]
     - [0x741000, asm]
     - [0x7558F0, asm]


### PR DESCRIPTION
I matched 6 of 9 functions in overlay2_73EA30.

The change to functions.us.h are unrelated and may have come from some unsuccessful matching attempts. I can try to get rid of it or maybe just leave it for when we get back to wherever that came from?